### PR TITLE
chore(plugins): reorder semantic release plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,9 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
+      "@semantic-release/npm",
       "@semantic-release/git",
-      "@semantic-release/npm"
+      "@semantic-release/github"
     ],
     "branch": "master"
   },


### PR DESCRIPTION
The npm plugin needs to be before git so that the git plugin can include it in the release commit. Furthermore, this adds the GitHub plugin in order to publish GitHub releases and comment on released Pull Requests/Issues.